### PR TITLE
fix: initials/pixel avatars keep their outline regardless of border prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.2.1] - 2026-08-11
+
+### Fixed
+
+- `border: false` on initials/pixel-art avatars no longer removes their outline — per the documented behavior, the `border` prop only controls the native `<img>` border; initials and pixel avatars always keep theirs. Previously `avatarStyle` incorrectly applied the same conditional as the image, contradicting the README's props table.
+- Image border removal (`border: false`) now sets `border: 0px` instead of `none`, avoiding a shorthand-serialization inconsistency and matching the component's own test suite.
+
 ## [4.2.0] - 2026-08-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue3-avatar",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "license": "MIT",
   "description": "A lightweight, fully customizable, accessible, and SSR-safe user avatar component for Vue 3 and Nuxt. Supports initials, custom images, pixel-art generation (identicons), groups with overflow, and auto-contrast text. Perfect for user profiles, team displays, and comment sections.",
   "main": "dist/avatar.ssr.js",

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -378,7 +378,7 @@ const imageStyle = computed(() => {
     justifyContent: "center",
     border: props.border
       ? `${size / 20}px solid ${displayBorderColor.value}`
-      : "none",
+      : "0px",
   };
   return Object.assign({}, defaultImageStyle, props.customAvatarStyle);
 });
@@ -394,7 +394,9 @@ const avatarStyle = computed(() => {
     display: props.inline && "inline-flex",
     borderRadius: shapeStyle.value.borderRadius,
     clipPath: shapeStyle.value.clipPath,
-    border: props.border && `${size / 20}px solid ${displayBorderColor.value}`,
+    // Initials/pixel-art avatars always keep their outline; `border` only
+    // toggles the native image border (see README props table).
+    border: `${size / 20}px solid ${displayBorderColor.value}`,
   };
   return Object.assign({}, defaultAvatarStyle, props.customAvatarStyle);
 });


### PR DESCRIPTION
border was incorrectly applied to avatarStyle the same way as imageStyle, contradicting the documented behavior (border only controls the native image border). Also switch the image's "no border" value from `none` to `0px` to avoid a shorthand-serialization inconsistency.

Bumps to 4.2.1 (patch).

## Summary

What does this PR change, and why?

## Related issue

Closes #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / internal
- [ ] Other:

## Checklist

- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Docs updated (`docs/` and/or `Readme.md`) if the public API changed
- [ ] `CHANGELOG.md` updated
